### PR TITLE
[CPL-20880] Provide guidance for errors

### DIFF
--- a/src/tools/get-dataflow/handler.test.ts
+++ b/src/tools/get-dataflow/handler.test.ts
@@ -23,6 +23,10 @@ const mockGetDataflowError = createMockResponse(
   async () => new Response('Error when getting dataflow', { status: 500 })
 )
 
+const mockGetDataflowErrorWithDetails = createMockResponse(
+  async () => new Response(JSON.stringify({ error: { message: 'Test error message' } }), { status: 500 })
+) 
+
 const mockFetch = vi.spyOn(globalThis, 'fetch')
 
 describe('get-dataflow', () => {
@@ -63,7 +67,22 @@ describe('get-dataflow', () => {
         isError: true,
         content: [{
           type: 'text',
-          text: 'Failed to get data flow gsheet_dataflow. Response status: 500',
+          text: 'Failed to get data flow gsheet_dataflow. Response status: 500.',
+        }]
+      })
+    })
+
+    it('includes error details when present', async () => {
+      mockFetch
+        .mockImplementationOnce(mockGetDataflowErrorWithDetails)
+
+      const toolResult = await handler({ dataflowId: 'gsheet_dataflow' })
+
+      expect(toolResult).toEqual({
+        isError: true,
+        content: [{
+          type: 'text',
+          text: 'Failed to get data flow gsheet_dataflow. Response status: 500. Error details: Test error message',
         }]
       })
     })

--- a/src/tools/get-dataflow/handler.ts
+++ b/src/tools/get-dataflow/handler.ts
@@ -3,7 +3,7 @@ import { fromError } from 'zod-validation-error'
 
 import { zodInputSchema } from './schema.js'
 
-import { textResponse } from '../../util/tool-response.js'
+import { textResponse, buildErrorMessage } from '../../util/tool-response.js'
 import { COUPLER_ACCESS_TOKEN } from '../../env.js'
 import { CouplerioClient } from '../../lib/couplerio-client/index.js'
 import { logger } from '../../logger/index.js'
@@ -33,10 +33,12 @@ export const handler = async (params?: Record<string, unknown>): Promise<CallToo
   })
 
   if (!response.ok) {
-    logger.error(`Failed to get data flow ${validationResult.data.dataflowId}. Response status: ${response.status}`)
+    const errorText = await buildErrorMessage( { response, customText: `Failed to get data flow ${validationResult.data.dataflowId}.`})
+    
+    logger.error(errorText)
     return textResponse({
       isError: true,
-      text: `Failed to get data flow ${validationResult.data.dataflowId}. Response status: ${response.status}`
+      text: errorText
     })
   }
 

--- a/src/tools/list-dataflows/handler.test.ts
+++ b/src/tools/list-dataflows/handler.test.ts
@@ -23,6 +23,12 @@ const mockListDataflowsError = createMockResponse(
   async () => new Response('Error listing dataflows', { status: 500 })
 )
 
+const mockGetDataflowErrorWithDetails = createMockResponse(
+  async () => new Response(
+    JSON.stringify({ error: { message: 'Test error message' } }), { status: 500 }
+  )
+)
+
 const mockFetch = vi.spyOn(globalThis, 'fetch')
 
 describe('listDataflows', () => {
@@ -63,7 +69,22 @@ describe('listDataflows', () => {
         isError: true,
         content: [{
           type: 'text',
-          text: 'Failed to list data flows. Response status: 500',
+          text: 'Failed to list data flows. Response status: 500.',
+        }]
+      })
+    })
+
+    it('includes error details when present', async () => {
+      mockFetch
+        .mockImplementationOnce(mockGetDataflowErrorWithDetails)
+
+      const toolResult = await handler()
+
+      expect(toolResult).toEqual({
+        isError: true,
+        content: [{
+          type: 'text',
+          text: 'Failed to list data flows. Response status: 500. Error details: Test error message',
         }]
       })
     })

--- a/src/tools/list-dataflows/handler.ts
+++ b/src/tools/list-dataflows/handler.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
-import { textResponse } from '../../util/tool-response.js'
+import { textResponse, buildErrorMessage } from '../../util/tool-response.js'
 import { COUPLER_ACCESS_TOKEN } from '../../env.js'
 import { CouplerioClient } from '../../lib/couplerio-client/index.js'
 import { logger } from '../../logger/index.js'
@@ -12,10 +12,12 @@ export const handler = async (): Promise<CallToolResult> => {
   const response = await coupler.request(`/dataflows?${query}{?type}`)
 
   if (!response.ok) {
-    logger.error(`Failed to list dataflows. Response status: ${response.status}`)
+    const errorText = await buildErrorMessage({ response, customText: 'Failed to list data flows.'})
+
+    logger.error(errorText)
     return textResponse({
       isError: true,
-      text: `Failed to list data flows. Response status: ${response.status}`
+      text: errorText
     })
   }
 

--- a/src/util/tool-response.ts
+++ b/src/util/tool-response.ts
@@ -17,3 +17,23 @@ export const textResponse = ({ text, isError = false, structuredContent }: { tex
 
   return callToolResult
 }
+
+export const buildErrorMessage = async ({
+  response,
+  customText = 'An unexpected error occurred.',
+}: {
+  response: Response,
+  customText: string,
+}): Promise<string> => {
+  let errorDetails = ''
+
+  try {
+    const { error } = (await response.json()) as { error?: { message?: string } }
+    errorDetails = error?.message ?? ''
+  } catch {
+    // Does not update for JSON parse errors
+  }
+
+  return `${customText} Response status: ${response.status}.` +
+         (errorDetails ? ` Error details: ${errorDetails}` : '')
+}

--- a/src/util/tool-response.ts
+++ b/src/util/tool-response.ts
@@ -1,4 +1,5 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { logger } from '../logger/index.js'
 
 export const textResponse = ({ text, isError = false, structuredContent }: { text: string, isError?: boolean, structuredContent?: Record<string, unknown> }) => {
   const callToolResult: CallToolResult = {
@@ -28,10 +29,11 @@ export const buildErrorMessage = async ({
   let errorDetails = ''
 
   try {
-    const { error } = (await response.json()) as { error?: { message?: string } }
+    const { error } = await response.json() as { error?: { message?: string } }
     errorDetails = error?.message ?? ''
-  } catch {
+  } catch (err){
     // Does not update for JSON parse errors
+    logger.error('Failed to parse JSON response', err)
   }
 
   return `${customText} Response status: ${response.status}.` +


### PR DESCRIPTION
This should tested / reviewed in coordination with the following PRs for:

web: [PR#6486 ](https://github.com/railsware/coupler-io-web/pull/6486)
remote-mcp: [PR#14](https://github.com/railsware/coupler-io-remote-mcp-server/pull/14) 

## Changes

- Added util to structure error message and pass in Error Details if passed from web-app in response: src/mcp/util/tool-response.ts
- Included this structured error message that includes error details in the returned error message in list-dataflow tool and get-dataflow tool. Other tools seem to already have human readable error messages.

## How to test
Same as[ testing for remote Claude](https://github.com/railsware/coupler-io-remote-mcp-server/pull/14) - but for desktop Claude
